### PR TITLE
change extended fuses to 0xfd

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -90,37 +90,37 @@ atmega328.build.board=atmega328
 atmega328.menu.clock.internal1=Internal 1 MHz
 atmega328.menu.clock.internal1.bootloader.low_fuses=0x62
 atmega328.menu.clock.internal1.bootloader.high_fuses=0xdb
-atmega328.menu.clock.internal1.bootloader.extended_fuses=0x05
+atmega328.menu.clock.internal1.bootloader.extended_fuses=0xfd
 atmega328.menu.clock.internal1.build.f_cpu=1000000L
 
 atmega328.menu.clock.internal8=Internal 8 MHz
 atmega328.menu.clock.internal8.bootloader.low_fuses=0xe2
 atmega328.menu.clock.internal8.bootloader.high_fuses=0xdb
-atmega328.menu.clock.internal8.bootloader.extended_fuses=0x05
+atmega328.menu.clock.internal8.bootloader.extended_fuses=0xfd
 atmega328.menu.clock.internal8.build.f_cpu=8000000L
 
 atmega328.menu.clock.external8=External 8 MHz
 atmega328.menu.clock.external8.bootloader.low_fuses=0xff
 atmega328.menu.clock.external8.bootloader.high_fuses=0xdb
-atmega328.menu.clock.external8.bootloader.extended_fuses=0x05
+atmega328.menu.clock.external8.bootloader.extended_fuses=0xfd
 atmega328.menu.clock.external8.build.f_cpu=8000000L
 
 atmega328.menu.clock.external12=External 12 MHz
 atmega328.menu.clock.external12.bootloader.low_fuses=0xff
 atmega328.menu.clock.external12.bootloader.high_fuses=0xdb
-atmega328.menu.clock.external12.bootloader.extended_fuses=0x05
+atmega328.menu.clock.external12.bootloader.extended_fuses=0xfd
 atmega328.menu.clock.external12.build.f_cpu=12000000L
 
 atmega328.menu.clock.external16=External 16 MHz
 atmega328.menu.clock.external16.bootloader.low_fuses=0xff
 atmega328.menu.clock.external16.bootloader.high_fuses=0xdb
-atmega328.menu.clock.external16.bootloader.extended_fuses=0x05
+atmega328.menu.clock.external16.bootloader.extended_fuses=0xfd
 atmega328.menu.clock.external16.build.f_cpu=16000000L
 
 atmega328.menu.clock.external20=External 20 MHz
 atmega328.menu.clock.external20.bootloader.low_fuses=0xff
 atmega328.menu.clock.external20.bootloader.high_fuses=0xdb
-atmega328.menu.clock.external20.bootloader.extended_fuses=0x05
+atmega328.menu.clock.external20.bootloader.extended_fuses=0xfd
 atmega328.menu.clock.external20.build.f_cpu=20000000L
 
 # Signature: ATmega328


### PR DESCRIPTION
Avrdude was complaining that unused bits of a fuse should be set to 1 and that we should be using 0xfd as the extended fuse instead of 0x05. If this is not fixed, future versions of avrdude will throw errors.